### PR TITLE
Update .NET Core framework

### DIFF
--- a/StorageTest/StorageTest.csproj
+++ b/StorageTest/StorageTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I'm not sure what other implications this has, but this was the fix I did to get things to work in the Azure Cloud Shell issue I encountered while going through this Learn module unit.

https://docs.microsoft.com/en-us/learn/modules/monitor-diagnose-and-troubleshoot-azure-storage/4-exercise-storage-metrics?source=learn

```
> dotnet run "<redacted>" testcontainer
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '2.2.0' was not found.
  - The following frameworks were found:
      3.1.9 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.

The specified framework can be found at:
  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=2.2.0&arch=x64&rid=cbld.10-x64
```

After this fix, I got the following output.

```
> dotnet run "DefaultEndpointsProtocol=https;AccountName={redacted};AccountKey={redacted};EndpointSuffix=core.windows.net" testcontainer
Running
Uploading blob 0
Uploading blob 1
Uploading blob 2
...
Uploading blob 98
Uploading blob 99
Downloading blob 0
Downloading blob 1
...
Downloading blob 98
Downloading blob 99
```